### PR TITLE
Correcting markdownlint config

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -23,7 +23,7 @@ globs:
 
 ignores:
 
-- ".markdownlint-cli2.yaml"
+- "_site/**/*.qmd"
 
 # Fix any fixable errors
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
   rev: v0.8.1
   hooks:
     - id: markdownlint-cli2
-      args: [.markdownlint-cli2.yaml]
+      args: []
 
 ci:
   autofix_prs: true


### PR DESCRIPTION
I'd mistakenly included `.markdownlint-cli2.yaml` as an `arg` to its configuration in `.pre-commit-config.yaml` and then found I had to `ignore:` the file in the `.markdownlint-cli2.yaml` file itself.

Corrected and now ignore `_site/**/*.qmd` as this directory is where the pages are rendered rather than being source.