### PR TITLE
feature: Add CNAME to resources

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,16 +59,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Add CNAME file to gh-pages branch
-        run: |
-          rm renv/activate.R
-          git switch gh-pages
-          git pull
-          echo 'blog.nshephard.dev' > CNAME
-          git add CNAME
-          git commit -m "Adding CNAME"
-          git push
-
       - name: Setup tmate session
         if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+blog.nshephard.dev

--- a/_quarto.yaml
+++ b/_quarto.yaml
@@ -7,6 +7,7 @@ project:
     - "*.qmd"
     - "*.sh"
     - "*.yaml"
+    - "CNAME"
 website:
   title: "blog.nshephard.dev"
   site-url: https://blog.nshephard.dev/


### PR DESCRIPTION
Adds `CNAME` file with custom domain to the repository (via `_quarto.yaml`) and removes the workflow step that added. :crossed_fingers:

Might close #150